### PR TITLE
Add isActive() method to identify when the element's splitter is being dragged

### DIFF
--- a/js/jquery.splitter-0.5.js
+++ b/js/jquery.splitter-0.5.js
@@ -82,7 +82,7 @@
             })(),
             orientation: settings.orientation,
             limit: settings.limit,
-			isActive: function() { return spliter_id === id; },
+            isActive: function() { return spliter_id === id; },
             destroy: function() {
                 spliter.unbind('mouseenter');
                 spliter.unbind('mouseleave');


### PR DESCRIPTION
The splitter has mouse and resize events that can be listened to, but it is not easy to know if the splitter is being dragged by the user or not.  With this change, it is possible for the user to listen to these events, and easily detect if the splitter is being dragged.

I enjoy jquery.splitter and find it to be a useful tool.  I'd really like to see jquery.splitter support this case.
