### PR TITLE
Fixed #28 Incorrect mouse cursor shape

### DIFF
--- a/js/jquery.splitter-0.14.0.js
+++ b/js/jquery.splitter-0.14.0.js
@@ -226,7 +226,7 @@
             $(document.documentElement).bind('mousedown.splitter', function(e) {
                 if (splitter_id !== null && e.which == 1) {
                     current_splitter = splitters[splitter_id];
-                    $('<div class="splitterMask"></div>').css('cursor', splitter.css('cursor')).insertAfter(current_splitter);
+                    $('<div class="splitterMask"></div>').css('cursor', current_splitter.children().eq(1).css('cursor')).insertAfter(current_splitter);
                     current_splitter.settings.onDragStart(e);
                     return false;
                 }


### PR DESCRIPTION
Fixed the correct splitter.

Explanation: 
Splitter Panel
  -- (1) Left/Top Panel 
  -- (2) h/v Splitter
  -- (3) Right/Bottom Panel```

I'm not sure how `splitter` is retrieved in `mousedown.splitter` function but it was incorrect.  

Changed to get splitter from the `Splitter Panel` i.e. second child element (2)