### PR TITLE
Fixing empty(`null`) splitters

### DIFF
--- a/js/jquery.splitter-0.15.0.js
+++ b/js/jquery.splitter-0.15.0.js
@@ -225,7 +225,7 @@
         if (splitters.length == 0) { // first time bind events to document
             $(window).bind('resize.splitter', function() {
                 $.each(splitters, function(i, splitter) {
-                    splitter.refresh();
+                    splitter && splitter.refresh && splitter.refresh();
                 });
             });
             $(document.documentElement).bind('mousedown.splitter touchstart.splitter', function(e) {


### PR DESCRIPTION
This will fix the empty splitters that become null when doing an `.destroy()`, but are still tried to be triggered when $(window) does a resize. I am getting errors when using multiple splitters in my screen, on a single page application (so triggers are being created or destroyed). This fixes it for me