### PR TITLE
Prevent error if mouseup happens immediately after mousedown

### DIFF
--- a/js/jquery.splitter.js
+++ b/js/jquery.splitter.js
@@ -375,8 +375,9 @@
                     // ignore right click
                     if (e.originalEvent.button !== 2) {
                         setTimeout(function() {
-                            if (!current_splitter)
+                            if (!current_splitter) {
                                 return;
+                            }
                             $('<div class="splitterMask"></div>').
                                 css('cursor', current_splitter.node.children().eq(1).css('cursor')).
                                 insertAfter(current_splitter.node);

--- a/js/jquery.splitter.js
+++ b/js/jquery.splitter.js
@@ -375,6 +375,8 @@
                     // ignore right click
                     if (e.originalEvent.button !== 2) {
                         setTimeout(function() {
+                            if (!current_splitter)
+                                return;
                             $('<div class="splitterMask"></div>').
                                 css('cursor', current_splitter.node.children().eq(1).css('cursor')).
                                 insertAfter(current_splitter.node);


### PR DESCRIPTION
Sometimes on touch devices, if you tap the splitter, the mouseup event will have fired before the timout of the mousedown runs, causing an error.