### PR TITLE
Fix for splitter ids being wrong after destroying splitters

### DIFF
--- a/js/jquery.splitter.js
+++ b/js/jquery.splitter.js
@@ -1,7 +1,3 @@
-                    current_splitter = {
-                        node: splitters[splitter_id],
-                        index: current_splitter_index
-                    };
 /*!
  * jQuery Spliter Plugin version 0.29.1
  * Copyright (C) 2010-2020 Jakub T. Jankiewicz <https://jcubic.pl/me>

--- a/js/jquery.splitter.js
+++ b/js/jquery.splitter.js
@@ -1,3 +1,7 @@
+                    current_splitter = {
+                        node: splitters[splitter_id],
+                        index: current_splitter_index
+                    };
 /*!
  * jQuery Spliter Plugin version 0.29.1
  * Copyright (C) 2010-2020 Jakub T. Jankiewicz <https://jcubic.pl/me>
@@ -299,7 +303,7 @@
                 self.trigger('splitter.resize');
                 self.find('.splitter_panel').trigger('splitter.resize');
                 splitters[id] = null;
-                count--;
+
                 $splitters.forEach(function($splitter) {
                     var splitter = $(this);
                     $splitter.off('mouseenter');


### PR DESCRIPTION
Because counts are used as id's, wrong splitters will be moved if splitters are being destroyed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed splitter instance tracking during destruction, ensuring proper cleanup of global event listeners and resource management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->